### PR TITLE
Adiciona documentclass de TCC

### DIFF
--- a/dist/coppe.cls
+++ b/dist/coppe.cls
@@ -72,6 +72,15 @@ T\kern-.1667em\lower.5ex\hbox{E}\kern-.125emX\spacefactor1000}
 \setboolean{maledoc}{false}
 \newif\if@english\@englishfalse
 \DeclareOption{english}{\@englishtrue}
+\DeclareOption{tcc}{%
+ \newcommand{\@degree}{B.Sc.}
+  \newcommand{\@degreename}{Bacharelado}
+  \newcommand{\local@degname}{Engenheiro}
+  \newcommand{\foreign@degname}{Engineer}
+  \setboolean{maledoc}{true}
+  \newcommand\local@doctype{Projeto de Gradua{\c c}{\~ a}o}
+  \newcommand\foreign@doctype{Undergraduate Project}
+}
 \DeclareOption{msc}{%
   \newcommand{\@degree}{M.Sc.}
   \newcommand{\@degreename}{Mestrado}

--- a/src/coppe.dtx
+++ b/src/coppe.dtx
@@ -629,6 +629,15 @@ T\kern-.1667em\lower.5ex\hbox{E}\kern-.125emX\spacefactor1000}
 % Otherwise, Portuguese is considered the main language.
 \newif\if@english\@englishfalse
 \DeclareOption{english}{\@englishtrue}
+\DeclareOption{tcc}{%
+ \newcommand{\@degree}{B.Sc.}
+  \newcommand{\@degreename}{Bacharelado}
+  \newcommand{\local@degname}{Engenheiro}
+  \newcommand{\foreign@degname}{Engineer}
+  \setboolean{maledoc}{true}
+  \newcommand\local@doctype{Projeto de Gradua{\c c}{\~ a}o}
+  \newcommand\foreign@doctype{Undergraduate Project}
+}
 \DeclareOption{msc}{%
   \newcommand{\@degree}{M.Sc.}
   \newcommand{\@degreename}{Mestrado}


### PR DESCRIPTION
Co-Authored-By: Matheus Moreno <matheus.moreno@poli.ufrj.br>

### O que esse PR faz?
Adiciona `documentclass` de TCC, para formação de bacharel. 

### Contribuições futuras:
A página de capa, no caso do TCC, é o [novo logo da Politécnica](https://www.poli.ufrj.br/arquivos/marcapolitecnica2020/MarcaPrincipal/Marca_Principal.png). Isso pode ser endereçado em um PR subsequente.