### PR TITLE
Update coppe.cls

### DIFF
--- a/src/coppe.cls
+++ b/src/coppe.cls
@@ -102,6 +102,15 @@ T\kern-.1667em\lower.5ex\hbox{E}\kern-.125emX\spacefactor1000}
   \newcommand\local@doctype{Exame de Qualifica{\c c}{\~ a}o}
   \newcommand\foreign@doctype{Qualifying Exam}
 }
+\DeclareOption{mscsem}{%
+ \newcommand{\@degree}{M.Sc.}
+  \newcommand{\@degreename}{Mestrado}
+  \newcommand{\local@degname}{Mestre}
+  \newcommand{\foreign@degname}{Master}
+  \setboolean{maledoc}{true}
+  \newcommand\local@doctype{Semin{\' a}rio}
+  \newcommand\foreign@doctype{Seminar}
+}
 \DeclareOption{dsc}{%
   \newcommand{\@degree}{D.Sc.}
   \newcommand{\@degreename}{Doutorado}


### PR DESCRIPTION
O Programa de Engenharia Mecânica da COPPE tem um seminário de mestrado como requisito obrigatório que, tecnicamente, é diferente de um exame de qualificação de mestrado. Dito isso, apenas adicionei a opção de seminário de mestrado com o nome "mscsem" na classe coppe.